### PR TITLE
Dual Application of Deadly Poison Rank 4 and Rank 5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.21
+FROM golang:1.23
 
 WORKDIR /classic
 COPY . .

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -479,7 +479,7 @@ message PetMiscConsumes {
 	bool juju_flurry = 1;
 }
 
-// NextIndex: 25
+// NextIndex: 26
 enum WeaponImbue {
 	// Weapon Oils
 	WeaponImbueUnknown = 0;
@@ -520,7 +520,8 @@ enum WeaponImbue {
 
 	// Rogue imbues
 	InstantPoison = 5;
-	DeadlyPoison = 6;
+	DeadlyPoisonRank4 = 6;
+	DeadlyPoisonRank5 = 25;
 	WoundPoison = 7;
 }
 

--- a/sim/rogue/poisons.go
+++ b/sim/rogue/poisons.go
@@ -178,15 +178,13 @@ func (rogue *Rogue) registerDeadlyPoisonRank4Spell() {
 		25: 9,
 		40: 13,
 		50: 20,
-		60: 27, // (Rank 4)
-		// 60: 34, // (Rank 5)
+		60: 27,
 	}[rogue.Level]
 	spellID := map[int32]int32{
 		25: 2823,
 		40: 2824,
 		50: 11355,
-		60: 11356, // (Rank 4)
-		// 60: 25351, // (Rank 5)
+		60: 11356,
 	}[rogue.Level]
 
 	rogue.deadlyPoisonRank4Tick = rogue.RegisterSpell(core.SpellConfig{
@@ -201,7 +199,7 @@ func (rogue *Rogue) registerDeadlyPoisonRank4Spell() {
 
 		Dot: core.DotConfig{
 			Aura: core.Aura{
-				Label:     "DeadlyPoison",
+				Label:     "DeadlyPoison (Rank 4)",
 				MaxStacks: 5,
 				Duration:  time.Second * 12,
 			},
@@ -233,20 +231,8 @@ func (rogue *Rogue) registerDeadlyPoisonRank4Spell() {
 }
 
 func (rogue *Rogue) registerDeadlyPoisonRank5Spell() {
-	baseDamageTick := map[int32]float64{
-		25: 9,
-		40: 13,
-		50: 20,
-		// 60: 27, // (Rank 4)
-		60: 34, // (Rank 5)
-	}[rogue.Level]
-	spellID := map[int32]int32{
-		25: 2823,
-		40: 2824,
-		50: 11355,
-		// 60: 11356, // (Rank 4)
-		60: 25351, // (Rank 5)
-	}[rogue.Level]
+	baseDamageTick := float64(34)
+	spellID := int32(25351)
 
 	rogue.deadlyPoisonRank5Tick = rogue.RegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: spellID, Tag: 100},
@@ -260,7 +246,7 @@ func (rogue *Rogue) registerDeadlyPoisonRank5Spell() {
 
 		Dot: core.DotConfig{
 			Aura: core.Aura{
-				Label:     "DeadlyPoison",
+				Label:     "DeadlyPoison (Rank 5)",
 				MaxStacks: 5,
 				Duration:  time.Second * 12,
 			},

--- a/sim/rogue/poisons.go
+++ b/sim/rogue/poisons.go
@@ -19,7 +19,7 @@ Deadly Poison: 30% proc chance, 5 stacks
 40: 52 damage, 2824 ID, 75 charges
 50: 80 damage, 11355 ID, 90 charges
 60: 108 damage, 11356 ID, 105 charges (Rank 4, Rank 5 is by book)
-60: 136 damage, 25347 ID, 120 charges (Rank 5)
+60: 136 damage, 25351 ID, 120 charges (Rank 5)
 
 Wound Poison: 30% proc chance, 5 stacks
 25: x damage, x ID (none, first rank is level 32)
@@ -186,7 +186,7 @@ func (rogue *Rogue) registerDeadlyPoisonRank4Spell() {
 		40: 2824,
 		50: 11355,
 		60: 11356, // (Rank 4)
-		// 60: 25347, // (Rank 5)
+		// 60: 25351, // (Rank 5)
 	}[rogue.Level]
 
 	rogue.deadlyPoisonRank4Tick = rogue.RegisterSpell(core.SpellConfig{
@@ -245,7 +245,7 @@ func (rogue *Rogue) registerDeadlyPoisonRank5Spell() {
 		40: 2824,
 		50: 11355,
 		// 60: 11356, // (Rank 4)
-		60: 25347, // (Rank 5)
+		60: 25351, // (Rank 5)
 	}[rogue.Level]
 
 	rogue.deadlyPoisonRank5Tick = rogue.RegisterSpell(core.SpellConfig{

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -68,10 +68,12 @@ type Rogue struct {
 
 	Evasion *core.Spell
 
-	DeadlyPoison     *core.Spell
-	deadlyPoisonTick *core.Spell
-	InstantPoison    *core.Spell
-	WoundPoison      *core.Spell
+	DeadlyPoisonRank4     *core.Spell
+	DeadlyPoisonRank5     *core.Spell
+	deadlyPoisonRank4Tick *core.Spell
+	deadlyPoisonRank5Tick *core.Spell
+	InstantPoison         *core.Spell
+	WoundPoison           *core.Spell
 
 	additivePoisonBonusChance float64
 
@@ -120,7 +122,8 @@ func (rogue *Rogue) Initialize() {
 
 	// Poisons
 	rogue.registerInstantPoisonSpell()
-	rogue.registerDeadlyPoisonSpell()
+	rogue.registerDeadlyPoisonRank4Spell()
+	rogue.registerDeadlyPoisonRank5Spell()
 	rogue.registerWoundPoisonSpell()
 
 	// Stealth

--- a/ui/core/components/inputs/consumables.ts
+++ b/ui/core/components/inputs/consumables.ts
@@ -37,7 +37,7 @@ import { makeBooleanConsumeInput, makeBooleanMiscConsumeInput, makeBooleanPetMis
 import { IconPicker, IconPickerDirection } from '../icon_picker';
 import * as InputHelpers from '../input_helpers';
 import { MultiIconPicker, MultiIconPickerConfig, MultiIconPickerItemConfig } from '../multi_icon_picker';
-import { DeadlyPoisonWeaponImbue, InstantPoisonWeaponImbue, WoundPoisonWeaponImbue } from './rogue_imbues';
+import { DeadlyPoisonWeaponRank4Imbue, DeadlyPoisonWeaponRank5Imbue, InstantPoisonWeaponImbue, WoundPoisonWeaponImbue } from './rogue_imbues';
 import { FlametongueWeaponImbue, FrostbrandWeaponImbue, RockbiterWeaponImbue, WindfuryWeaponImbue } from './shaman_imbues';
 import { ActionInputConfig, ItemStatOption, PickerStatOptions, StatOptions } from './stat_options';
 
@@ -803,7 +803,7 @@ export const Windfury: ConsumableInputConfig<WeaponImbue> = {
 	actionId: () => ActionId.fromSpellId(10614),
 	value: WeaponImbue.Windfury,
 	showWhen: player => {
-		return (player.getFaction() === Faction.Horde) && !player.isSpec(Spec.SpecFeralDruid)
+		return player.getFaction() === Faction.Horde && !player.isSpec(Spec.SpecFeralDruid);
 	},
 };
 
@@ -989,7 +989,8 @@ const SHAMAN_IMBUES = (slot: ItemSlot): ConsumableStatOption<WeaponImbue>[] => [
 
 const ROGUE_IMBUES: ConsumableStatOption<WeaponImbue>[] = [
 	{ config: InstantPoisonWeaponImbue, stats: [] },
-	{ config: DeadlyPoisonWeaponImbue, stats: [] },
+	{ config: DeadlyPoisonWeaponRank4Imbue, stats: [] },
+	{ config: DeadlyPoisonWeaponRank5Imbue, stats: [] },
 	{ config: WoundPoisonWeaponImbue, stats: [] },
 ];
 

--- a/ui/core/components/inputs/rogue_imbues.ts
+++ b/ui/core/components/inputs/rogue_imbues.ts
@@ -9,9 +9,17 @@ export const InstantPoisonWeaponImbue: ConsumableInputConfig<WeaponImbue> = {
 	showWhen: player => player.getClass() == Class.ClassRogue,
 };
 
-export const DeadlyPoisonWeaponImbue: ConsumableInputConfig<WeaponImbue> = {
+export const DeadlyPoisonWeaponRank4Imbue: ConsumableInputConfig<WeaponImbue> = {
 	actionId: () => ActionId.fromItemId(8985),
-	value: WeaponImbue.DeadlyPoison,
+	value: WeaponImbue.DeadlyPoisonRank4,
+	// value: WeaponImbue.DeadlyPoisonRank4,
+	showWhen: player => player.getClass() == Class.ClassRogue,
+};
+
+export const DeadlyPoisonWeaponRank5Imbue: ConsumableInputConfig<WeaponImbue> = {
+	actionId: () => ActionId.fromItemId(20844),
+	value: WeaponImbue.DeadlyPoisonRank5,
+	// value: WeaponImbue.DeadlyPoisonRank5,
 	showWhen: player => player.getClass() == Class.ClassRogue,
 };
 

--- a/ui/rogue/presets.ts
+++ b/ui/rogue/presets.ts
@@ -11,28 +11,28 @@ import {
 	IndividualBuffs,
 	Profession,
 	RaidBuffs,
+	SapperExplosive,
 	SaygesFortune,
 	SpellPowerBuff,
 	StrengthBuff,
 	TristateEffect,
 	WeaponImbue,
 	ZanzaBuff,
-	SapperExplosive,
 } from '../core/proto/common.js';
 import { RogueOptions } from '../core/proto/rogue.js';
 import { SavedTalents } from '../core/proto/ui.js';
 import BackstabAPL from './apls/combat_backstab.apl.json';
 import BackstabSweatyAPL from './apls/combat_backstab_sweaty.apl.json';
 import SinisterStrikeAPL from './apls/combat_sinister_strike.apl.json';
-import SinisterStrikeSweatyAPL from './apls/combat_sinister_strike_sweaty.apl.json';
 import SinisterStrikeIEAAPL from './apls/combat_sinister_strike_iea.apl.json';
+import SinisterStrikeSweatyAPL from './apls/combat_sinister_strike_sweaty.apl.json';
 import BlankGear from './gear_sets/blank.gear.json';
-import BackstabGearPreBiS from './gear_sets/combat_backstab_prebis.gear.json';
-import SinisterStrikeGearPreBiS from './gear_sets/combat_sinister_strike_prebis.gear.json';
 import BackstabGearP1BiS from './gear_sets/combat_backstab_p1_bis.gear.json';
 import BackstabGearP2BiS from './gear_sets/combat_backstab_p2_bis.gear.json';
+import BackstabGearPreBiS from './gear_sets/combat_backstab_prebis.gear.json';
 import SinisterStrikeGearP1BiS from './gear_sets/combat_sinister_strike_p1_bis.gear.json';
 import SinisterStrikeGearP2BiS from './gear_sets/combat_sinister_strike_p2_bis.gear.json';
+import SinisterStrikeGearPreBiS from './gear_sets/combat_sinister_strike_prebis.gear.json';
 
 // Preset options for this spec.
 // Eventually we will import these values for the raid sim too, so its good to
@@ -68,8 +68,20 @@ export const ROTATION_PRESET_SINISTER_STRIKE_SWEATY = PresetUtils.makePresetAPLR
 export const ROTATION_PRESET_SINISTER_STRIKE_IEA = PresetUtils.makePresetAPLRotation('Improved Expose Armor (SS)', SinisterStrikeIEAAPL, {});
 
 export const APLPresets = {
-	[Phase.Phase1]: [ROTATION_PRESET_BACKSTAB, ROTATION_PRESET_SINISTER_STRIKE, ROTATION_PRESET_BACKSTAB_SWEATY, ROTATION_PRESET_SINISTER_STRIKE_SWEATY, ROTATION_PRESET_SINISTER_STRIKE_IEA],
-	[Phase.Phase2]: [ROTATION_PRESET_BACKSTAB, ROTATION_PRESET_SINISTER_STRIKE, ROTATION_PRESET_BACKSTAB_SWEATY, ROTATION_PRESET_SINISTER_STRIKE_SWEATY, ROTATION_PRESET_SINISTER_STRIKE_IEA],
+	[Phase.Phase1]: [
+		ROTATION_PRESET_BACKSTAB,
+		ROTATION_PRESET_SINISTER_STRIKE,
+		ROTATION_PRESET_BACKSTAB_SWEATY,
+		ROTATION_PRESET_SINISTER_STRIKE_SWEATY,
+		ROTATION_PRESET_SINISTER_STRIKE_IEA,
+	],
+	[Phase.Phase2]: [
+		ROTATION_PRESET_BACKSTAB,
+		ROTATION_PRESET_SINISTER_STRIKE,
+		ROTATION_PRESET_BACKSTAB_SWEATY,
+		ROTATION_PRESET_SINISTER_STRIKE_SWEATY,
+		ROTATION_PRESET_SINISTER_STRIKE_IEA,
+	],
 };
 
 //Need to add main hand equip logic or talent/rotation logic to map to Auto APL
@@ -91,12 +103,15 @@ export const DefaultAPLIEA = APLPresets[Phase.Phase2][4];
 
 // Preset name must be unique. Ex: 'Backstab DPS' cannot be used as a name more than once
 
-export const CombatBackstabTalents = PresetUtils.makePresetTalents(
-	'Backstab',
-	SavedTalents.create({ talentsString: '005023104-0233050020550100221-05' }),
+export const CombatBackstabTalents = PresetUtils.makePresetTalents('Backstab', SavedTalents.create({ talentsString: '005023104-0233050020550100221-05' }));
+export const CombatSinisterStrikeTalents = PresetUtils.makePresetTalents(
+	'Sinister Strike',
+	SavedTalents.create({ talentsString: '005323105-0240052020050150231' }),
 );
-export const CombatSinisterStrikeTalents = PresetUtils.makePresetTalents('Sinister Strike', SavedTalents.create({ talentsString: '005323105-0240052020050150231' }));
-export const CombatSinisterStrikeIEATalents = PresetUtils.makePresetTalents('Improved Expose Armor (SS)', SavedTalents.create({ talentsString: '005323123-0240052020050150231' }));
+export const CombatSinisterStrikeIEATalents = PresetUtils.makePresetTalents(
+	'Improved Expose Armor (SS)',
+	SavedTalents.create({ talentsString: '005323123-0240052020050150231' }),
+);
 
 export const TalentPresets = {
 	[Phase.Phase1]: [CombatBackstabTalents, CombatSinisterStrikeTalents, CombatSinisterStrikeIEATalents],
@@ -150,7 +165,7 @@ export const P1Consumes = Consumes.create({
 	flask: Flask.FlaskOfSupremePower,
 	food: Food.FoodGrilledSquid,
 	mainHandImbue: WeaponImbue.InstantPoison,
-	offHandImbue: WeaponImbue.DeadlyPoison,
+	offHandImbue: WeaponImbue.DeadlyPoisonRank4,
 	spellPowerBuff: SpellPowerBuff.GreaterArcaneElixir,
 	strengthBuff: StrengthBuff.JujuPower,
 	zanzaBuff: ZanzaBuff.GroundScorpokAssay,
@@ -169,7 +184,7 @@ export const P1RaidBuffs = RaidBuffs.create({
 	strengthOfEarthTotem: TristateEffect.TristateEffectImproved,
 	graceOfAirTotem: TristateEffect.TristateEffectImproved,
 	leaderOfThePack: true,
-	trueshotAura: true, 
+	trueshotAura: true,
 });
 
 export const DefaultRaidBuffs = {


### PR DESCRIPTION
With the new Deadly Poison Rank 5 it's beneficial to use Deadly Poison Rank 5 on Mainhand and Deadly Poison Rank 4 on Offhand as long you're the only rogue using them.

I edited the current Weapon Imbue Deadly Poison to Rank 4 and added a new Weapon Imbue for Deadly Poison Rank 5. 

As this is my first PR, pls guide me to clean this up or prepare, if it can't be merged that way. I ran "make test", but there are no tests files for /sim/rogue.

The Dockerfile change was required for me to use "docker build". As I got this error on Windows with WSL and Docker: 
`0.401 go: go.mod requires go >= 1.23.0 (running go 1.21.13; GOTOOLCHAIN=local)`
Doesn't seem to hurt, but can be reverted, of course.