### PR TITLE
Adds StatFrostResistance in mage sim epWeights to avoid the engine filtering this stat

### DIFF
--- a/ui/mage/sim.ts
+++ b/ui/mage/sim.ts
@@ -69,6 +69,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecMage, {
 			[Stat.StatSpellHaste]: 6.85,
 			[Stat.StatMP5]: 0.11,
 			[Stat.StatFireResistance]: 0.5,
+			[Stat.StatFrostResistance]: 0.5,
 		}),
 		// Default consumes settings.
 		consumes: Presets.DefaultConsumes,


### PR DESCRIPTION
Closes #162 

I updated the sim for mages (Adding StatFrostResistance) in epWeights to avoid the engine filtering this stat.